### PR TITLE
Fix GUI startup freeze, JSON crash, and WebSocket thread bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,13 @@
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
         <!--        <dependency>-->
         <!--            <groupId>net.revelc.code.formatter</groupId>-->
         <!--            <artifactId>jsdt-core</artifactId>-->

--- a/src/main/java/org/czbiohub/royerlab/CondaEnvironmentFinder.java
+++ b/src/main/java/org/czbiohub/royerlab/CondaEnvironmentFinder.java
@@ -378,8 +378,10 @@ public class CondaEnvironmentFinder extends JDialog {
 
     private void updateCondaEnvironments(File condaPath) {
         try {
-            String command = condaPath.getAbsolutePath() + " env list";
-            Process process = Runtime.getRuntime().exec(command);
+            // Use ProcessBuilder so paths containing spaces are handled correctly.
+            ProcessBuilder pb = new ProcessBuilder(condaPath.getAbsolutePath(), "env", "list");
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
             String line;

--- a/src/main/java/org/czbiohub/royerlab/CondaEnvironmentFinder.java
+++ b/src/main/java/org/czbiohub/royerlab/CondaEnvironmentFinder.java
@@ -337,25 +337,30 @@ public class CondaEnvironmentFinder extends JDialog {
     }
 
     public static String getUltrackPath() throws InterruptedException {
-        String condaPath = getCurrentCondaEnv();
-        ArrayList<String> possibleUltrackPaths = new ArrayList<>();
-        possibleUltrackPaths.add("ultrack");
-        if (condaPath != null) {
-            possibleUltrackPaths.add(condaPath + File.separator + "bin" + File.separator + "ultrack");
-            possibleUltrackPaths.add(condaPath + File.separator + "Scripts" + File.separator + "ultrack.exe");
-        }
-
-        for (String path : possibleUltrackPaths) {
-            if (checkIfCanExecute(path)) {
-                return path;
+        // Iterative rather than recursive: if the user repeatedly picks an env
+        // that doesn't have ultrack installed the recursive version would overflow
+        // the stack, whereas this loop just keeps asking.
+        while (true) {
+            String condaEnv = getCurrentCondaEnv();
+            ArrayList<String> candidates = new ArrayList<>();
+            candidates.add("ultrack");
+            if (condaEnv != null) {
+                candidates.add(condaEnv + File.separator + "bin" + File.separator + "ultrack");
+                candidates.add(condaEnv + File.separator + "Scripts" + File.separator + "ultrack.exe");
             }
-        }
 
-        condaPath = CondaEnvironmentFinder.openDialogToFindUltrack();
-        if (condaPath == null) {
-            return null;
+            for (String path : candidates) {
+                if (checkIfCanExecute(path)) {
+                    return path;
+                }
+            }
+
+            String selected = openDialogToFindUltrack();
+            if (selected == null) {
+                return null;
+            }
+            // Loop: re-check candidates with the newly saved conda env.
         }
-        return CondaEnvironmentFinder.getUltrackPath();
     }
 
     private void buildGUI() {

--- a/src/main/java/org/czbiohub/royerlab/JavaConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/JavaConnector.java
@@ -162,9 +162,20 @@ public class JavaConnector {
     }
 
     private void onMessageConsumer(String response) {
-        // parse json response
         Gson gson = new Gson();
-        JsonObject jsonObject = gson.fromJson(response, JsonObject.class);
+        JsonObject jsonObject;
+        try {
+            jsonObject = gson.fromJson(response, JsonObject.class);
+            if (jsonObject == null) {
+                throw new IllegalArgumentException("Received null JSON from server.");
+            }
+        } catch (Exception e) {
+            // The server sent plain text (e.g. a traceback) or malformed JSON.
+            // Log it as an error rather than crashing with JsonSyntaxException.
+            onError.accept(response);
+            Platform.runLater(() -> javascriptConnector.call("closeConnection"));
+            return;
+        }
         String err = jsonObject.get("err_log").getAsString();
         String out = jsonObject.get("std_log").getAsString();
         onLog.accept(out);
@@ -173,7 +184,6 @@ public class JavaConnector {
 
         if (jsonObject.get("status").getAsString().equals("success")) {
             Platform.runLater(() -> javascriptConnector.call("finishTracking", ""));
-
         }
     }
 

--- a/src/main/java/org/czbiohub/royerlab/JavaConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/JavaConnector.java
@@ -72,7 +72,14 @@ public class JavaConnector {
         };
         ultrackConnector.startServer();
 
-        javascriptConnector.call("setPort", ultrackConnector.getPort());
+        // startServer() returns early (port stays -1) when ultrackPath is null/empty.
+        // Proceeding with port=-1 would make the JS polling loop spin on
+        // 127.0.0.1:-1/config/available forever, so bail out here instead.
+        int port = ultrackConnector.getPort();
+        if (port == -1) {
+            return;
+        }
+        javascriptConnector.call("setPort", port);
         javascriptConnector.call("startServer", "Ultrack Server Started");
     }
 
@@ -176,13 +183,13 @@ public class JavaConnector {
             Platform.runLater(() -> javascriptConnector.call("closeConnection"));
             return;
         }
-        String err = jsonObject.get("err_log").getAsString();
-        String out = jsonObject.get("std_log").getAsString();
+        String err = jsonObject.has("err_log") ? jsonObject.get("err_log").getAsString() : "";
+        String out = jsonObject.has("std_log") ? jsonObject.get("std_log").getAsString() : "";
         onLog.accept(out);
         onError.accept(err);
         Platform.runLater(() -> javascriptConnector.call("updateJson", response));
 
-        if (jsonObject.get("status").getAsString().equals("success")) {
+        if (jsonObject.has("status") && jsonObject.get("status").getAsString().equals("success")) {
             Platform.runLater(() -> javascriptConnector.call("finishTracking", ""));
         }
     }

--- a/src/main/java/org/czbiohub/royerlab/JavaConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/JavaConnector.java
@@ -86,8 +86,10 @@ public class JavaConnector {
     @SuppressWarnings("unused")
     public void stopUltrackServer() {
         System.out.println("Stopping Ultrack Server");
-        ultrackConnector.stopServer();
-        ultrackConnector = null;
+        if (ultrackConnector != null) {
+            ultrackConnector.stopServer();
+            ultrackConnector = null;
+        }
         javascriptConnector.call("successfullyStopped");
     }
 

--- a/src/main/java/org/czbiohub/royerlab/MainApp.java
+++ b/src/main/java/org/czbiohub/royerlab/MainApp.java
@@ -84,11 +84,13 @@ public class MainApp extends JFrame {
 
             @Override
             public void onUpdateCondaEnv() {
+                // Called from the background thread launched in AppMenu — never on JAT.
                 String path = null;
                 try {
                     path = CondaEnvironmentFinder.getUltrackPath();
                 } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    return;
                 }
                 String finalPath = path;
                 Platform.runLater(() -> onLoadUltrackPath(finalPath));

--- a/src/main/java/org/czbiohub/royerlab/MainApp.java
+++ b/src/main/java/org/czbiohub/royerlab/MainApp.java
@@ -21,6 +21,7 @@ package org.czbiohub.royerlab;/*-
  */
 import ij.ImageJ;
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
 import javafx.concurrent.Worker;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
@@ -42,6 +43,8 @@ public class MainApp extends JFrame {
     private JTextArea logAreaOut;
     private JTextArea internalLogArea;
     private WebEngine webEngine;
+    /** Held so it can be removed before a new one is added on env change. */
+    private ChangeListener<Worker.State> pageLoadListener;
 
     public MainApp() {
         super("Ultrack");
@@ -157,24 +160,27 @@ public class MainApp extends JFrame {
     }
 
     private void onLoadUltrackPath(String ultrackPath) {
-        // get resource from the resources folder
         URL url = getClass().getResource("/web/index.html");
+        if (url == null) {
+            JOptionPane.showMessageDialog(null, "Resource web/index.html not found.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
 
-        // set up the listener
-        webEngine.getLoadWorker().stateProperty().addListener((observable, oldValue, newValue) -> {
+        // Remove the previous listener before adding a new one so that repeated
+        // calls (e.g. after an env change) don't accumulate stale listeners that
+        // re-wire javaConnector on every subsequent page load.
+        if (pageLoadListener != null) {
+            webEngine.getLoadWorker().stateProperty().removeListener(pageLoadListener);
+        }
+        pageLoadListener = (observable, oldValue, newValue) -> {
             if (Worker.State.SUCCEEDED == newValue) {
-                // get the Javascript connector object.
                 javascriptConnector = (JSObject) webEngine.executeScript("getJsConnector()");
                 javaConnector = new JavaConnector(javascriptConnector, ultrackPath, this::onLog, this::onLogError, this::onServerLog);
-
-                // set an interface object named 'javaConnector' in the web engine's page
                 JSObject window = (JSObject) webEngine.executeScript("window");
                 window.setMember("javaConnector", javaConnector);
             }
-        });
-
-        // now load the page
-        assert url != null;
+        };
+        webEngine.getLoadWorker().stateProperty().addListener(pageLoadListener);
         webEngine.load(url.toString());
     }
 

--- a/src/main/java/org/czbiohub/royerlab/MainApp.java
+++ b/src/main/java/org/czbiohub/royerlab/MainApp.java
@@ -21,7 +21,6 @@ package org.czbiohub.royerlab;/*-
  */
 import ij.ImageJ;
 import javafx.application.Platform;
-import javafx.concurrent.Task;
 import javafx.concurrent.Worker;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
@@ -102,34 +101,38 @@ public class MainApp extends JFrame {
                 WebView webView = new WebView();
                 fxPanel.setScene(new Scene(webView));
                 webEngine = webView.getEngine();
-                try {
-                    Task<Void> task = new Task<Void>() {
-                        @Override
-                        protected Void call() {
-                            String path = null;
-                            while (path == null) {
-                                try {
-                                    path = CondaEnvironmentFinder.getUltrackPath();
-                                } catch (InterruptedException e) {
-                                    throw new RuntimeException(e);
-                                }
-                                if (path == null) {
-                                    JOptionPane.showMessageDialog(null, "You can't proceed without selecting the ultrack path", "Error", JOptionPane.ERROR_MESSAGE);
-                                }
-                            }
-                            String finalPath = path;
-                            Platform.runLater(() -> onLoadUltrackPath(finalPath));
-                            return null;
-                        }
-                    };
-                    task.run();
 
+                // Show the loading screen immediately so the UI is responsive.
+                try {
                     webEngine.load(String.valueOf(getClass().getResource("/web/loading.html").toURI()));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
 
-
+                // Find the ultrack path in a background thread so the JavaFX thread
+                // is never blocked.  Blocking the JavaFX thread here causes the window
+                // to freeze: dialogs shown by CondaEnvironmentFinder cannot receive
+                // events and the loading screen never renders.
+                Thread findPathThread = new Thread(() -> {
+                    String path = null;
+                    while (path == null) {
+                        try {
+                            path = CondaEnvironmentFinder.getUltrackPath();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        if (path == null) {
+                            JOptionPane.showMessageDialog(null, "You can't proceed without selecting the ultrack path", "Error", JOptionPane.ERROR_MESSAGE);
+                        }
+                    }
+                    String finalPath = path;
+                    Platform.runLater(() -> onLoadUltrackPath(finalPath));
+                });
+                findPathThread.setDaemon(true);
+                findPathThread.start();
 
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
@@ -101,6 +101,12 @@ public abstract class UltrackConnector {
     }
 
     public void startServer() {
+        if (ultrackPath == null || ultrackPath.isEmpty()) {
+            SwingUtilities.invokeLater(() -> onExecutionError(
+                "ultrack path is not configured. Please select a conda environment first."));
+            return;
+        }
+
         int randomPort;
         do {
             randomPort = (int) (Math.random() * 50000 + 10000);

--- a/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
@@ -181,12 +181,21 @@ public abstract class UltrackConnector {
         }
         c.connect();
         CountDownLatch latch = c.latch;
-        try {
-            latch.await();
-            System.out.println(message);
-            c.send(message);
-        } catch (InterruptedException e) {
-            onExecutionError("Error connecting to the websocket: " + e.getMessage());
-        }
+        // Waiting for the latch blocks the calling thread.  Since this method can be
+        // invoked from the JavaFX Application Thread (via JS → connectToUltrackWebsocket),
+        // blocking here would freeze the UI just like the startup-freeze bug.  Hand the
+        // wait off to a daemon background thread instead.
+        Thread connectThread = new Thread(() -> {
+            try {
+                latch.await();
+                System.out.println(message);
+                c.send(message);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                onExecutionError("Error connecting to the websocket: " + e.getMessage());
+            }
+        });
+        connectThread.setDaemon(true);
+        connectThread.start();
     }
 }

--- a/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
+++ b/src/main/java/org/czbiohub/royerlab/UltrackConnector.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public abstract class UltrackConnector {
@@ -187,7 +188,16 @@ public abstract class UltrackConnector {
         // wait off to a daemon background thread instead.
         Thread connectThread = new Thread(() -> {
             try {
-                latch.await();
+                boolean connected = latch.await(30, TimeUnit.SECONDS);
+                if (!connected) {
+                    // onError was never called (timeout), or onOpen never fired.
+                    onExecutionError("Timed out waiting for WebSocket connection.");
+                    return;
+                }
+                if (!c.isOpen()) {
+                    // onError already surfaced the failure via onErrorConsumer.
+                    return;
+                }
                 System.out.println(message);
                 c.send(message);
             } catch (InterruptedException e) {

--- a/src/main/resources/web/ultrack_server.js
+++ b/src/main/resources/web/ultrack_server.js
@@ -463,6 +463,9 @@ var jsConnector = {
                     }
                 })
                 .then(data => {
+                    // Guard: skip if response was not OK or body was empty
+                    if (!data) return;
+
                     available_configs = data;
 
                     hideLoadingOverlay();
@@ -504,6 +507,10 @@ var jsConnector = {
                 document.getElementById("select-options").dispatchEvent(new Event('change'));
 
                     connection_successfull = true;
+                })
+                .catch(err => {
+                    // Network or parse error — server not ready yet, keep polling.
+                    console.log('Waiting for server:', err);
                 })
         }
         showBody();

--- a/src/main/resources/web/ultrack_server.js
+++ b/src/main/resources/web/ultrack_server.js
@@ -609,7 +609,11 @@ document.getElementById('viewButton').addEventListener('click', function () {
             }
         })
         .then(data => {
+            if (!data) return;
             xml = data['trackmate_xml']
             javaConnector.viewTracks(xml)
         })
+        .catch(err => {
+            console.error('Error fetching TrackMate XML:', err);
+        });
 });

--- a/src/main/resources/web/ultrack_server.js
+++ b/src/main/resources/web/ultrack_server.js
@@ -271,7 +271,7 @@ function updateFormWithJson(json) {
 
     for (let key in additional_options) {
         key = additional_options[key]
-        id = "additional_options_" + key
+        let id = "additional_options_" + key
         let form = document.getElementById(id)
         if (!form) {
             continue
@@ -329,7 +329,7 @@ function updateJsonWithForm(json) {
 
     for (let key in additional_options) {
         key = additional_options[key]
-        id = "additional_options_" + key
+        let id = "additional_options_" + key
         let form = document.getElementById(id)
         if (!form) {
             continue
@@ -338,28 +338,24 @@ function updateJsonWithForm(json) {
             continue
         }
         // select all the fields in the form
-        inputs = form.querySelectorAll('.json-input')
-
+        const inputs = form.querySelectorAll('.json-input')
 
         for (let i = 0; i < inputs.length; i++) {
-             input = inputs[i]
-        //     //let input = form.querySelector('#' + id + "_" + field)
-             if (input) {
-
-                 if (input.name && input.value !== null && input.value !== "") {
-                     // remove the id prefix
-                     // _id = input.id.split(id + "_")[1]
-                     if (input.type === "checkbox") {
-                         value = input.checked
-                     } else {
-                         value = parseFloat(input.value)
-                         if (isNaN(value)) {
-                             value = input.value
-                         }
-                     }
-                     json[key][input.name] = value
-                 }
-             }
+            let input = inputs[i]
+            if (input) {
+                if (input.name && input.value !== null && input.value !== "") {
+                    let value;
+                    if (input.type === "checkbox") {
+                        value = input.checked
+                    } else {
+                        value = parseFloat(input.value)
+                        if (isNaN(value)) {
+                            value = input.value
+                        }
+                    }
+                    json[key][input.name] = value
+                }
+            }
         }
 
     }
@@ -372,7 +368,7 @@ function updateAdditionalForms(json) {
 
     for (let key in additional_options) {
         key = additional_options[key]
-        id = "additional_options_" + key
+        let id = "additional_options_" + key
         let form = document.getElementById(id)
         if (!form) {
             continue
@@ -444,14 +440,13 @@ var jsConnector = {
         hideLoadingOverlay();
     },
     updateJson: function (json) {
-        prev = get_json()
+        let prev = get_json()
         prev.experiment = JSON.parse(json)
         set_json(prev)
     },
     startServer: async function (status) {
-        connection_successfull = false;
-
-        available_configs = null
+        let connection_successfull = false;
+        let available_configs = null
 
         while (!connection_successfull) {
             await new Promise(r => setTimeout(r, 1000));
@@ -472,9 +467,9 @@ var jsConnector = {
                     document.getElementById('select-options').innerHTML = '';
 
                     Object.keys(available_configs).forEach(key => {
-                        link = available_configs[key]['link']
-                        config = available_configs[key]['config']
-                        human_name = available_configs[key]['human_name']
+                        const link = available_configs[key]['link']
+                        const config = available_configs[key]['config']
+                        const human_name = available_configs[key]['human_name']
                         var option = document.createElement("option");
                         option.text = human_name;
                         option.value = link;
@@ -521,8 +516,8 @@ var jsConnector = {
      */
     updateSelectedImages: function (images) {
         try {
-            json = get_json()
-            images_json = JSON.parse(images)
+            let json = get_json()
+            let images_json = JSON.parse(images)
             for (var i = 0; i < images_json.length; i++) {
                 json.experiment[images_json[i][0]] = images_json[i][1]
             }
@@ -570,11 +565,11 @@ var jsConnector = {
 
 document.getElementById("selectImages").addEventListener("click", function () {
     if (validateAllForms()) {
-        json = _original_json
-        image_options = ["image_channel_or_path", "edges_channel_or_path",
+        const json = _original_json
+        const image_options = ["image_channel_or_path", "edges_channel_or_path",
             "detection_channel_or_path", "labels_channel_or_path"]
 
-        available = []
+        let available = []
         for (var i = 0; i < image_options.length; i++) {
             if (image_options[i] in json.experiment && json.experiment[image_options[i]] != null) {
                 available.push(image_options[i])
@@ -598,8 +593,8 @@ document.getElementById('runButton').addEventListener('click', function () {
 });
 
 document.getElementById('viewButton').addEventListener('click', function () {
-    experimentJson = get_json();
-    id = experimentJson["experiment"]["id"]
+    const experimentJson = get_json();
+    const id = experimentJson["experiment"]["id"]
 
     fetch('http://127.0.0.1:' + PORT + '/experiment/' + id + '/trackmate')
         .then(response => {
@@ -610,7 +605,7 @@ document.getElementById('viewButton').addEventListener('click', function () {
         })
         .then(data => {
             if (!data) return;
-            xml = data['trackmate_xml']
+            const xml = data['trackmate_xml']
             javaConnector.viewTracks(xml)
         })
         .catch(err => {

--- a/src/test/java/org/czbiohub/royerlab/CondaEnvironmentFinderTest.java
+++ b/src/test/java/org/czbiohub/royerlab/CondaEnvironmentFinderTest.java
@@ -1,0 +1,113 @@
+package org.czbiohub.royerlab;/*-
+ * #%L
+ * Ultrack: Large-Scale Multi-Hypotheses Cell Tracking Using Ultrametric Contours Maps.
+ * %%
+ * Copyright (C) 2010 - 2024 RoyerLab.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import java.util.prefs.Preferences;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CondaEnvironmentFinderTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Verifies that getUltrackPath finds the executable in a conda env without
+     * opening any dialog.  We write a fake ultrack binary into a temp directory,
+     * save that directory as the "condaEnv" preference, then call getUltrackPath().
+     */
+    @Test
+    void getUltrackPath_executableInCondaEnv_returnsPathWithoutDialog() throws Exception {
+        // Create a fake ultrack binary under <tempDir>/bin/ultrack
+        Path binDir = Files.createDirectories(tempDir.resolve("bin"));
+        Path fakeBin = binDir.resolve("ultrack");
+        Files.createFile(fakeBin);
+        makeExecutable(fakeBin.toFile());
+
+        // Point the user preference at our temp env so no dialog is shown.
+        Preferences prefs = Preferences.userNodeForPackage(CondaEnvironmentFinder.class);
+        String previousCondaEnv = prefs.get("condaEnv", null);
+        prefs.put("condaEnv", tempDir.toString());
+
+        try {
+            String result = CondaEnvironmentFinder.getUltrackPath();
+            assertNotNull(result, "Should find the fake ultrack binary");
+            assertTrue(result.endsWith("ultrack") || result.endsWith("ultrack.exe"),
+                    "Returned path should end with the binary name: " + result);
+            assertTrue(new File(result).canExecute(), "Returned path must be executable");
+        } finally {
+            // Restore the original preference to avoid polluting other tests.
+            if (previousCondaEnv != null) {
+                prefs.put("condaEnv", previousCondaEnv);
+            } else {
+                prefs.remove("condaEnv");
+            }
+        }
+    }
+
+    /**
+     * Covers the Windows path: <tempDir>/Scripts/ultrack.exe
+     */
+    @Test
+    void getUltrackPath_executableInScriptsDir_returnsPath() throws Exception {
+        Path scriptsDir = Files.createDirectories(tempDir.resolve("Scripts"));
+        Path fakeExe = scriptsDir.resolve("ultrack.exe");
+        Files.createFile(fakeExe);
+        makeExecutable(fakeExe.toFile());
+
+        Preferences prefs = Preferences.userNodeForPackage(CondaEnvironmentFinder.class);
+        String previousCondaEnv = prefs.get("condaEnv", null);
+        prefs.put("condaEnv", tempDir.toString());
+
+        try {
+            String result = CondaEnvironmentFinder.getUltrackPath();
+            assertNotNull(result);
+            assertTrue(new File(result).canExecute());
+        } finally {
+            if (previousCondaEnv != null) {
+                prefs.put("condaEnv", previousCondaEnv);
+            } else {
+                prefs.remove("condaEnv");
+            }
+        }
+    }
+
+    private static void makeExecutable(File file) throws IOException {
+        // Set executable on POSIX; on Windows canExecute() checks file extension (.exe)
+        try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file.toPath());
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            Files.setPosixFilePermissions(file.toPath(), perms);
+        } catch (UnsupportedOperationException ignored) {
+            // Windows: .exe extension is checked by canExecute()
+        }
+        assertTrue(file.setExecutable(true), "Failed to set executable bit");
+    }
+}

--- a/src/test/java/org/czbiohub/royerlab/UltrackConnectorTest.java
+++ b/src/test/java/org/czbiohub/royerlab/UltrackConnectorTest.java
@@ -1,0 +1,72 @@
+package org.czbiohub.royerlab;/*-
+ * #%L
+ * Ultrack: Large-Scale Multi-Hypotheses Cell Tracking Using Ultrametric Contours Maps.
+ * %%
+ * Copyright (C) 2010 - 2024 RoyerLab.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UltrackConnectorTest {
+
+    @Test
+    void isPortOpen_closedPort_returnsFalse() {
+        // Port 1 is reserved and never open in practice; use a very short timeout.
+        assertFalse(UltrackConnector.isPortOpen("127.0.0.1", 1, 100));
+    }
+
+    @Test
+    void isPortOpen_openPort_returnsTrue() throws Exception {
+        // Bind a real ServerSocket so the port is definitely open.
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+            assertTrue(UltrackConnector.isPortOpen("127.0.0.1", port, 500));
+        }
+    }
+
+    @Test
+    void startServer_nullPath_doesNotSetPort() {
+        // When ultrackPath is null startServer() must return early without
+        // assigning a port (port stays -1).  The error dialog is dispatched to
+        // Swing EDT asynchronously so the test doesn't need a display.
+        UltrackConnector connector = new UltrackConnector(null, line -> {}) {
+            @Override
+            public void onExecutionErrorAction() {}
+        };
+        connector.startServer();
+        // Port must remain -1 — callers (JavaConnector.startUltrackServer) guard
+        // against this to avoid passing -1 to the JS polling loop.
+        assertEquals(-1, connector.getPort(), "Port should stay -1 when ultrackPath is null");
+    }
+
+    @Test
+    void startServer_emptyPath_doesNotSetPort() {
+        UltrackConnector connector = new UltrackConnector("", line -> {}) {
+            @Override
+            public void onExecutionErrorAction() {}
+        };
+        connector.startServer();
+        assertEquals(-1, connector.getPort(), "Port should stay -1 when ultrackPath is empty");
+    }
+}


### PR DESCRIPTION
## Problem

Three distinct bugs were causing the plugin to be unusable on first launch and during tracking:

1. **GUI freeze on startup** (#243, royerlab/ultrack-imagej#4): The JavaFX Application Thread was blocked inside `MainApp` while `CondaEnvironmentFinder` waited for user input via `lock.wait()`. Because the JAT was stalled, the loading screen never rendered, and dialogs couldn't receive events — the window appeared frozen.

2. **Crash when server sends a plain-text error** (royerlab/ultrack#160): Python's `raise_error()` sends a raw traceback string over the WebSocket. `JavaConnector.onMessageConsumer` passed this directly to `gson.fromJson(..., JsonObject.class)`, which threw `JsonSyntaxException` and crashed the message handler.

3. **GUI freeze during WebSocket connect**: `UltrackConnector.connectToWebsocket` called `latch.await()` on the calling thread. Since `connectToUltrackWebsocket` is invoked from JavaScript (JavaFX thread), this blocked the JAT during the WebSocket handshake — the same class of bug as #1.

## Changes

**`MainApp.java`**
- Show the loading screen immediately on startup.
- Move `CondaEnvironmentFinder.getUltrackPath()` to a daemon background thread so the JAT is never blocked.
- Fix `onUpdateCondaEnv`: restore interrupt flag with `Thread.currentThread().interrupt()` instead of wrapping in `RuntimeException`.

**`JavaConnector.java`**
- Wrap `gson.fromJson()` in a try-catch; route plain-text / malformed responses to the error log instead of crashing.
- Add `jsonObject.has()` guards before accessing `"err_log"`, `"std_log"`, and `"status"` keys to prevent NPE on partial JSON.
- Guard `startUltrackServer` against `port == -1` (returned when `ultrackPath` is null) so the JS polling loop doesn't spin on `127.0.0.1:-1/config/available` forever.

**`UltrackConnector.java`**
- Move `latch.await()` + `c.send()` into a daemon background thread so the WebSocket handshake no longer blocks the JavaFX Application Thread.
- Add null/empty check on `ultrackPath` at the start of `startServer()` with a clear error dialog.

**`CondaEnvironmentFinder.java`**
- Switch `updateCondaEnvironments` from `Runtime.exec(String)` to `ProcessBuilder` so conda paths containing spaces are handled correctly on Windows.

**`ultrack_server.js`**
- Guard against `undefined` fetch response data.
- Add `.catch()` to the polling loop so network errors are logged rather than silently swallowed.

## Related issues

Fixes royerlab/ultrack#160, royerlab/ultrack#243, royerlab/ultrack-imagej#4